### PR TITLE
Correctly report deploy errors

### DIFF
--- a/Scripts/DeployToEnvironment.ps1
+++ b/Scripts/DeployToEnvironment.ps1
@@ -124,13 +124,15 @@ $startEpiDeploymentSplat = @{
     ProjectId = "$ProjectID"
     Wait = $false
     TargetEnvironment = "$TargetEnvironment"
-    UseMaintenancePage = $UseMaintenancePage
     ClientSecret = "$ClientSecret"
     ClientKey = "$ClientKey"
 }
 
 if($DirectDeploy -eq $true){
     $startEpiDeploymentSplat.Add("DirectDeploy", $true)
+}
+if($UseMaintenancePage -eq $true){
+    $startEpiDeploymentSplat.Add("UseMaintenancePage", $true)
 }
 
 
@@ -199,10 +201,14 @@ start-sleep -Milliseconds 1000
 #If the status is set to Failed, throw an error
 if($status -eq "Failed"){
     Write-Output "##vso[task.complete result=Failed;]"
-    throw "Deployment Failed. Errors: \n" + $deploy.deploymentErrors
+    $errors = $currDeploy | Select -ExpandProperty deploymentErrors
+    throw "Deployment Failed. Errors: \n" + $errors
 }
 
+#Get links for validation
+$validationLinks = $currDeploy | Select -ExpandProperty validationLinks
 Write-Host "Deployment Complete"
+Write-Host "Please verify at $validationLinks"
 
 #Set the Output variable for the Deployment ID, if needed
 Write-Output "##vso[task.setvariable variable=DeploymentId;]'$deployId'"

--- a/Scripts/PromoteToEnvironment.ps1
+++ b/Scripts/PromoteToEnvironment.ps1
@@ -141,11 +141,13 @@ $startEpiDeploymentSplat = @{
 
 if($IncludeCode){
     $startEpiDeploymentSplat.Add("SourceApp", $SourceApp)
-    $startEpiDeploymentSplat.Add("UseMaintenancePage", $UseMaintenancePage)
 }
 
 if($DirectDeploy -eq $true){
     $startEpiDeploymentSplat.Add("DirectDeploy", $true)
+}
+if($UseMaintenancePage -eq $true){
+    $startEpiDeploymentSplat.Add("UseMaintenancePage", $true)
 }
 
 if(![string]::IsNullOrWhiteSpace($ZeroDownTimeMode)){
@@ -212,7 +214,8 @@ start-sleep -Milliseconds 1000
 
 #If the status is set to Failed, throw an error
 if($status -eq "Failed"){
-    throw "Deployment Failed. Errors: \n" + $deploy.deploymentErrors
+    $errors = $currDeploy | Select -ExpandProperty deploymentErrors
+    throw "Deployment Failed. Errors: \n" + $errors
 }
 
 Write-Host "Deployment Complete"


### PR DESCRIPTION
I encountered an issue with a deploy that was failing. The error messages were always empty:

```
2025-06-03T16:46:25.2881334Z Deployment Failed. Errors: \n
```

I made some updates to ensure that the error messages come through correctly.

* Use the `ExpandProperty` function to get the values from the `deploymentErrors` array. This mirrors how `validationLinks` is retrieved.
* Use `currDeploy` instead of `deploy`. The error messages would be in the most recent iteration of data returned by `Get-EpiDeployment`, not the original deploy object.
* To ensure uniform handling of booleans, I switched `UseMaintenancePage` to follow the same syntax as `DirectDeploy`.

Now I am able to see the error messages:

```
2025-06-03T18:04:39.1551174Z Deployment Failed. Errors: \nThe use of a maintenance page or ZeroDownTimeMode together with DirectDeploy is not 
2025-06-03T18:04:39.1551598Z supported. (The use of a maintenance page or ZeroDownTimeMode together with DirectDeploy is not supported.) Runbook 
2025-06-03T18:04:39.1557857Z job failed
```
